### PR TITLE
Provided Duration to response class

### DIFF
--- a/src/Http/Request/CurlWrap.php
+++ b/src/Http/Request/CurlWrap.php
@@ -14,6 +14,8 @@ namespace Eophantasy\Http\Request;
 use CurlHandle;
 use Eophantasy\Http\Response\Response;
 use Eophantasy\Http\Response\ResponseBasic;
+use Eophantasy\Time\Duration\Now;
+use Eophantasy\Time\Duration\Since;
 use Exception;
 
 /**
@@ -50,9 +52,9 @@ final class CurlWrap
      */
     public function response(): Response
     {
-        $startMs = microtime(true);
+        $startDur = new Now();
         $response = curl_exec($this->curlHandle);
-        $endMs = microtime(true);
+        $resposeEnded = new Since($startDur);
         curl_close($this->curlHandle);
 
         if ($response === false) {
@@ -73,7 +75,7 @@ final class CurlWrap
         return new ResponseBasic(
             $response,
             $statusCode,
-            $endMs - $startMs
+            $resposeEnded
         );
     }
 }

--- a/src/Http/Response/Response.php
+++ b/src/Http/Response/Response.php
@@ -12,6 +12,7 @@
 namespace Eophantasy\Http\Response;
 
 use Eophantasy\IO\Reader;
+use Eophantasy\Time\Durationable;
 
 /**
  * An interface for reading HTTP responses.
@@ -20,7 +21,7 @@ use Eophantasy\IO\Reader;
  * 
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages
  */
-interface Response extends Reader
+interface Response extends Reader, Durationable
 {
     /**
      * Returns the status code.

--- a/src/Http/Response/ResponseBasic.php
+++ b/src/Http/Response/ResponseBasic.php
@@ -11,6 +11,7 @@
 
 namespace Eophantasy\Http\Response;
 
+use Eophantasy\Time\Duration\Duration;
 use Eophantasy\Type\Bytes\Bytes;
 use Eophantasy\Type\Bytes\BytesByString;
 
@@ -24,30 +25,17 @@ use Eophantasy\Type\Bytes\BytesByString;
 final class ResponseBasic implements Response
 {
     /**
-     * The body.
-     * 
-     * @var string
-     */
-    private $body;
-
-    /**
-     * The status code.
-     * 
-     * @var int
-     */
-    private $statusCode;
-
-    /**
      * Constructs a new Response.
      * 
      * @param string $body The body.
      * @param int $statusCode The status code.
+     * @param Duration $duration The duration.
      */
-    public function __construct(string $body, int $statusCode)
-    {
-        $this->body = $body;
-        $this->statusCode = $statusCode;
-    }
+    public function __construct(
+        private string $body,
+        private int $statusCode,
+        private Duration $duration
+    ) {}
 
     /**
      * Reads the body content as bytes.
@@ -67,5 +55,15 @@ final class ResponseBasic implements Response
     public function statusCode(): int
     {
         return $this->statusCode;
+    }
+
+    /**
+     * Returns the duration of time.
+     * 
+     * @return Duration
+     */
+    public function duration(): Duration
+    {
+        return $this->duration;
     }
 }

--- a/src/Time/Durationable.php
+++ b/src/Time/Durationable.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Eophantasy package.
+ *
+ * (c) Ilya Sitnikov <sitnikovik@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eophantasy\Time;
+
+use Eophantasy\Time\Duration\Duration;
+
+/**
+ * An interface for classes that represent a duration of time.
+ */
+interface Durationable
+{
+    /**
+     * Returns the duration of time.
+     * 
+     * @return Duration The duration of time.
+     */
+    public function duration(): Duration;
+}

--- a/tests/Http/Request/RequestBasicTest.php
+++ b/tests/Http/Request/RequestBasicTest.php
@@ -36,6 +36,7 @@ final class RequestBasicTest extends TestCase
      * @covers RequestBasic::response
      * @covers RequestBasic::__construct
      * @covers ResponseBasic::read
+     * @covers ResponseBasic::duration
      * @covers ResponseBasic::__construct
      */
     public function testResponse()
@@ -60,6 +61,10 @@ final class RequestBasicTest extends TestCase
         $this->assertEquals(
             200,
             $response->statusCode()
+        );
+        $this->assertGreaterThanOrEqual(
+            0,
+            $response->duration()->milliseconds(),
         );
 
         $jsonDecoded = json_decode(


### PR DESCRIPTION
Add Durationable interface for time duration representation. Implement it in Response and ResponseBasic classes. 
Refactor CurlWrap to use Duration classes for response timing and update tests to validate duration.
