### PR TITLE
Implement proxy support for HTTP requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ composer.phar
 /.obsidian
 VERSION
 
+# Hide this test case it stores the proxy settings
+tests/Http/Request/RequestWithProxyTest.php
+
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock

--- a/src/Http/Proxy/Proxy.php
+++ b/src/Http/Proxy/Proxy.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Eophantasy package.
+ *
+ * (c) Ilya Sitnikov <sitnikovik@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eophantasy\Http\Proxy;
+
+use CurlHandle;
+use Eophantasy\Http\Request\Url\Host\Host;
+use Exception;
+use Stringable;
+
+/**
+ * A class representing a proxy.
+ * 
+ * A proxy is an intermediary server that separates the user from the websites they browse.
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxies
+ */
+class Proxy implements Stringable
+{
+    /**
+     * The constructor.
+     * 
+     * @param Host $host The proxy host.
+     */
+    public function __construct(
+        private Host $host
+    ) {}
+
+    /**
+     * Represents the proxy as string.
+     * 
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->host->__toString();
+    }
+
+    /**
+     * @inheritDoc
+     * @override
+     */
+    public function wrapCurl(CurlHandle $curl): CurlHandle
+    {
+        $newCurl = curl_copy_handle($curl);
+        if ($newCurl === false) {
+            throw new Exception('Failed to copy cURL handle');
+        }
+        curl_setopt($newCurl, CURLOPT_PROXY, $this->__toString());
+
+        return $newCurl;
+    }
+}

--- a/src/Http/Proxy/ProxyWithAuth.php
+++ b/src/Http/Proxy/ProxyWithAuth.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Eophantasy package.
+ *
+ * (c) Ilya Sitnikov <sitnikovik@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eophantasy\Http\Proxy;
+
+use CurlHandle;
+
+/**
+ * A class representing a proxy with authentication.
+ * 
+ * A proxy is an intermediary server that separates the user from the websites they browse.
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers
+ */
+final class ProxyWithAuth extends Proxy
+{
+    /**
+     * Creates a new proxy with authentication.
+     * 
+     * @param Proxy $origin The original proxy.
+     * @param string $username The username for the proxy.
+     * @param string $password The password for the proxy.
+     */
+    public function __construct(
+        private Proxy $origin,
+        private string $username,
+        private string $password,
+    ) {}
+
+    /**
+     * Returns the username for the proxy.
+     * 
+     * @return string
+     */
+    public function username(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * Returns the password for the proxy.
+     * 
+     * @return string
+     */
+    public function password(): string
+    {
+        return $this->password;
+    }
+
+    /**
+     * @inheritDoc
+     * @override
+     */
+    public function wrapCurl(CurlHandle $curl): CurlHandle
+    {
+        $newCurl = $this->origin->wrapCurl($curl);
+        curl_setopt($newCurl, CURLOPT_PROXYUSERPWD, $this->username() . ':' . $this->password());
+
+        return $newCurl;
+    }
+}

--- a/src/Http/Proxy/ProxyWithoutSSL.php
+++ b/src/Http/Proxy/ProxyWithoutSSL.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Eophantasy package.
+ *
+ * (c) Ilya Sitnikov <sitnikovik@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eophantasy\Http\Proxy;
+
+use CurlHandle;
+
+/**
+ * A class representing a proxy without SSL verification.
+ * 
+ * A proxy is an intermediary server that separates the user from the websites they browse.
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxies
+ */
+final class ProxyWithoutSSL extends Proxy
+{
+    /**
+     * Creates a new proxy without SSL.
+     * 
+     * @param Proxy $origin The original proxy.
+     */
+    public function __construct(
+        private Proxy $origin
+    ) {}
+
+    /**
+     * @inheritDoc
+     * @override
+     */
+    public function wrapCurl(CurlHandle $curl): CurlHandle
+    {
+        $newCurl = $this->origin->wrapCurl($curl);
+        curl_setopt($newCurl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($newCurl, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($newCurl, CURLOPT_FOLLOWLOCATION, true); // Следовать за редиректами
+
+        return $newCurl;
+    }
+}

--- a/src/Http/Request/CurlWrap.php
+++ b/src/Http/Request/CurlWrap.php
@@ -18,7 +18,6 @@ use Eophantasy\Http\Response\Status\Code;
 use Eophantasy\Http\Response\Status\CodeByCurl;
 use Eophantasy\Time\Duration\Now;
 use Eophantasy\Time\Duration\Since;
-use Exception;
 
 /**
  * A class representing a cURL wrapper.

--- a/src/Http/Request/RequestWithProxy.php
+++ b/src/Http/Request/RequestWithProxy.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Eophantasy package.
+ *
+ * (c) Ilya Sitnikov <sitnikovik@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eophantasy\Http\Request;
+
+use CurlHandle;
+use Eophantasy\Http\Proxy\Proxy;
+use Eophantasy\Http\Response\Response;
+
+/**
+ * A class representing an HTTP request with a proxy.
+ * 
+ * This class is used to send HTTP requests to a server via a proxy to hide the previous client information.
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers
+ */
+final class RequestWithProxy implements Request
+{
+    /**
+     * Creates a new request with a proxy.
+     * 
+     * @param Request $origin The original request.
+     * @param Proxy $proxy The proxy to use.
+     */
+    public function __construct(
+        private Request $origin,
+        private Proxy $proxy
+    ) {}
+
+    /**
+     * Returns the original request.
+     * 
+     * @return Request
+     */
+    public function origin(): Request
+    {
+        return $this->origin;
+    }
+
+    /**
+     * Returns the proxy.
+     * 
+     * @return Proxy
+     */
+    public function proxy(): Proxy
+    {
+        return $this->proxy;
+    }
+
+    /**
+     * @inheritDoc
+     * @override
+     */
+    public function cURL(): CurlHandle
+    {
+        return $this->proxy->wrapCurl(
+            $this->origin->cURL()
+        );
+    }
+
+    /**
+     * @inheritDoc
+     * @override
+     */
+    public function response(): Response
+    {
+        return (new CurlWrap(
+            $this->cURL()
+        ))->response();
+    }
+}


### PR DESCRIPTION
- Add basic Proxy class using the host.
- Add Proxy with authentication.
- Add Proxy without SSL verification.
- Add RequestWithProxy to send http requests via proxy server.